### PR TITLE
Improving visualising VisData

### DIFF
--- a/ctr-tools/CTRFramework/CTRFramework.Code/lev/Scene.cs
+++ b/ctr-tools/CTRFramework/CTRFramework.Code/lev/Scene.cs
@@ -635,6 +635,51 @@ namespace CTRFramework
             return tex;
         }
 
+        /// <summary>
+        /// Returns VisData children
+        /// </summary>
+        /// <param name="visData"></param>
+        public List<VisData> GetVisDataChildren(VisData visData)
+        {
+            List<VisData> childVisData = new List<VisData>();
+            if (visData.leftChild != 0 && !visData.IsLeaf) // in the future: handle leaves different. Draw them?
+            {
+                ushort uLeftChild = (ushort) (visData.leftChild & 0x3fff);
+                VisData leftChild = visdata.Find(cc => cc.id == uLeftChild);
+                childVisData.Add(leftChild);
+            }
+            if (visData.rightChild != 0 && !visData.IsLeaf) // in the future: handle leaves different. Draw them?
+            {
+                ushort uRightChild = (ushort) (visData.rightChild & 0x3fff);
+                VisData rightChild = visdata.Find(cc => cc.id == uRightChild);
+                childVisData.Add(rightChild);
+            } 
+
+            return childVisData;
+        }
+
+        private int levelShiftOffset = -52; // offset (found in Unity)
+        private int levelShiftDivide = 92; // one step width
+        
+        /// <summary>
+        /// Return QuadBlocks associated with the leaf, make sure you pass a leaf and not a branch.
+        /// </summary>
+        /// <param name="leaf"></param>
+        public List<QuadBlock> GetListOfLeafQuadBlocks(VisData leaf)
+        {
+            List<QuadBlock> leafQuadBlocks = new List<QuadBlock>();
+            uint ptrQuadBlock = (uint) (((leaf.ptrQuadBlock) / levelShiftDivide) + levelShiftOffset);
+            uint numQuadBlock = leaf.numQuadBlock;
+            for (int i = 0; i < numQuadBlock; i++)
+            {
+                long index = ptrQuadBlock + i;
+                QuadBlock quad = quads[(int) Math.Min(Math.Max(index, 0), quads.Count - 1)];
+                leafQuadBlocks.Add(quad);
+            }
+
+            return leafQuadBlocks;
+        }
+
         public void Dispose()
         {
             header = null;

--- a/ctr-tools/ctrviewer/Game1.cs
+++ b/ctr-tools/ctrviewer/Game1.cs
@@ -537,17 +537,7 @@ namespace ctrviewer
 
             foreach (Scene s in scn)
             {
-                foreach (var b in s.visdata)
-                {
-                    if (b.IsLeaf)
-                    {
-                        bbox.Add(MGConverter.ToLineList(b.bbox, Color.Red));
-                    }
-                    else
-                    {
-                        bbox2.Add(MGConverter.ToLineList(b.bbox, Color.Green));
-                    }    
-                }
+                BspDraw(s.visdata[0], s, 0);
             }
 
             sw.Stop();
@@ -557,6 +547,43 @@ namespace ctrviewer
             UpdateEffects();
 
             RenderEnabled = true;
+        }
+
+        private readonly Color[] colorLevelsOfBsp =
+        {
+            new Color(1.0f,1.0f,1.0f,1.0f),
+            new Color(1.0f,1.0f,0.7f,1.0f),
+            new Color(1.0f,0.7f,0.7f,1.0f),
+            new Color(0.7f,0.7f,0.7f,1.0f),
+            new Color(0.7f,0.7f,0.5f,1.0f),
+            new Color(0.7f,0.5f,0.5f,1.0f),
+            new Color(0.5f,0.5f,0.5f,1.0f),
+            new Color(0.5f,0.5f,0.3f,1.0f),
+            new Color(0.5f,0.3f,0.3f,1.0f),
+            new Color(0.3f,0.3f,0.3f,1.0f),
+            new Color(0.3f,0.3f,0.0f,1.0f),
+            new Color(0.3f,0.0f,0.0f,1.0f),
+            new Color(0.0f,0.0f,0.0f,1.0f)
+        };
+        private void BspDraw(VisData visDat, Scene scene, int level)
+        {
+            List<VisData> childVisData = scene.GetVisDataChildren(visDat); // if node has children get those children
+            if (childVisData != null && childVisData.Count > 0)  // has any children?
+            {
+                foreach (var b in childVisData)
+                {
+                    if (b.IsLeaf) // leaves don't have children
+                    {
+                        bbox2.Add(MGConverter.ToLineList(b.bbox, Color.Magenta));
+                    }
+                    else
+                    {
+                        BspDraw(b, scene, level + 1);
+                        // show those children in different color than the parent
+                        bbox.Add(MGConverter.ToLineList(b.bbox, colorLevelsOfBsp[level % colorLevelsOfBsp.Length]));
+                    }    
+                }
+            }
         }
 
         public void ResetCamera()


### PR DESCRIPTION
Trying to improve visualizing the BSP tree.
`GetVisDataChildren(VisData visData)` will return VisData's child nodes. 

BSP data structure visualised:
```
                       0 node
               /                     \
        1 node                         4 node
   /              \               /              \
2 node            3 node         5 node            6 node
```


left node's index is always less than right node.

To render the game finds the most closest and deepest node where the camera lays in. Then it goes up the tree and rendering each steps child nodes.
If the game can't find the camera deep enough you'll see rendering glitches.