### PR TITLE
Water animation is a LUT based on water_data in .lev.

### DIFF
--- a/ctr-tools/CTRFramework/Code/lev/WaterAnim.cs
+++ b/ctr-tools/CTRFramework/Code/lev/WaterAnim.cs
@@ -11,6 +11,7 @@ namespace CTRFramework
     {
         public PsxPtr ptrVertex;
         public PsxPtr ptrWaterAnim;
+        public UInt16[] waterAnimation = new UInt16[28];
 
         public WaterAnim(BinaryReaderEx br)
         {
@@ -26,6 +27,24 @@ namespace CTRFramework
         {
             ptrVertex = PsxPtr.FromReader(br);
             ptrWaterAnim = PsxPtr.FromReader(br);
+            var currentPointer = br.BaseStream.Position;
+            br.Jump(ptrWaterAnim.Address);
+            for (int i = 0; i < 28; i++)
+            {
+                var color = br.ReadUInt16();
+                /*  Based on RE the maths is:
+                 *  var a = (color & 0x003f) / 63f;
+                 *  var b = ((color & 0x0fc0) >> 6) / 63f;
+                 *  var c = ((color & 0xf000) >> 12) / 15f;
+                 * 
+                 * (uVar3 & 0x3f) << 4
+                 * (uVar3 & 0xfc0) >> 2
+                 * (uVar3 & 0xf000) >> 4 | (uVar3 & 0xf000) >> 8
+                 * Color(b,b,max(a,b),c)? can someone verify?
+                 */
+                waterAnimation[i] = color;
+            }
+            br.Jump(currentPointer);
         }
     }
 }


### PR DESCRIPTION
This seemed to create the right look but maybe verify. Regardless this data is uint16 that signifies a color which is interpolated. Based on the RE code in AnimateWaterVertex. iirc. there's other data that also assumes 28 frames per second like the reserve system so it's not so unexpected.
 ```
               var color4b = br.ReadUInt16();
                var a = (color4b & 0x003f) / 63f;
                var b = ( (color4b & 0x0fc0) >> 6 ) / 63f;
                var c = ( (color4b & 0xf000) >> 12 ) / 15f;
                animation[i] = new Color(
                    b,
                    b,
                    Mathf.Max(b,a),
                    1f-c
                        );
```